### PR TITLE
Add serializers to hide some information

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'jbuilder', '~> 2.0'
 gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'unicorn'
 gem 'responders'
+gem 'active_model_serializers', github: 'rails-api/active_model_serializers'
 
 group :development, :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: git://github.com/rails-api/active_model_serializers.git
+  revision: f2f747eddaaa9fe9a2446630849227317cddea66
+  specs:
+    active_model_serializers (0.10.0)
+      actionpack (>= 4.1, < 6)
+      activemodel (>= 4.1, < 6)
+      jsonapi (~> 0.1.1.beta2)
+      railties (>= 4.1, < 6)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -71,6 +81,8 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
+    jsonapi (0.1.1.beta2)
+      json (~> 1.8)
     kgio (2.10.0)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
@@ -177,6 +189,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers!
   byebug
   coffee-rails (~> 4.1.0)
   database_cleaner

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -23,7 +23,7 @@ class Api::V1::ItemsController < Api::ApiController
 
   private
   def item_params
-    if params.keys.include?(:unit_price)
+    if params.keys.include?("unit_price")
       {unit_price: (params[:unit_price] * 100)}
     else
       params.permit(:id, :name, :description, :merchant_id, :created_at, :updated_at)

--- a/app/serializers/customer_serializer.rb
+++ b/app/serializers/customer_serializer.rb
@@ -1,0 +1,3 @@
+class CustomerSerializer < ActiveModel::Serializer
+  attributes :id, :first_name, :last_name
+end

--- a/app/serializers/invoice_serializer.rb
+++ b/app/serializers/invoice_serializer.rb
@@ -1,0 +1,3 @@
+class InvoiceSerializer < ActiveModel::Serializer
+  attributes :id, :customer_id, :merchant_id, :status
+end

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -1,0 +1,8 @@
+class ItemSerializer < ActiveModel::Serializer
+  attributes :id, :merchant_id, :name, :description
+  attribute :decimal_price, key: :unit_price
+
+  def decimal_price
+    (object.unit_price.to_f / 100).to_s
+  end
+end

--- a/app/serializers/merchant_serializer.rb
+++ b/app/serializers/merchant_serializer.rb
@@ -1,0 +1,3 @@
+class MerchantSerializer < ActiveModel::Serializer
+  attributes :id, :name
+end

--- a/app/serializers/transaction_serializer.rb
+++ b/app/serializers/transaction_serializer.rb
@@ -1,0 +1,3 @@
+class TransactionSerializer < ActiveModel::Serializer
+  attributes :id, :invoice_id, :credit_card_number, :result
+end


### PR DESCRIPTION
Use serializers to limit information being served by api in order to comply with spec harness.

Also, update items_controller to accurately pull an item based on its price.
