### PR TITLE
Adjust price reporting for InvoiceItem to be in dollars

### DIFF
--- a/app/serializers/invoice_item_serializer.rb
+++ b/app/serializers/invoice_item_serializer.rb
@@ -1,0 +1,8 @@
+class InvoiceItemSerializer < ActiveModel::Serializer
+  attributes :id, :invoice_id, :item_id, :quantity
+  attribute :decimal_price, key: :unit_price
+
+  def decimal_price
+    (object.unit_price.to_f / 100).to_s
+  end
+end

--- a/spec/requests/api/v1/invoice_item_find_all_spec.rb
+++ b/spec/requests/api/v1/invoice_item_find_all_spec.rb
@@ -48,6 +48,6 @@ RSpec.describe "GET /api/v1/invoice_items/find_all?parameters=:parameters" do
     expect(json_body.count).to eq(2)
     first_invoice = json_body[0]
     expect(first_invoice["id"]).to eq(invoice_item1.id)
-    expect(first_invoice["unit_price"]).to eq(invoice_item1.unit_price)
+    expect(first_invoice["unit_price"]).to eq((invoice_item1.unit_price/100.0).to_s)
   end
 end

--- a/spec/requests/api/v1/invoice_item_find_spec.rb
+++ b/spec/requests/api/v1/invoice_item_find_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "GET /api/v1/invoice_items/find?parameters=:parameters" do
 
     expect(json_body["id"]).to eq(invoice_item.id)
     expect(json_body["invoice_id"]).to eq(invoice_item.invoice_id)
+    expect(json_body["unit_price"]).to eq((invoice_item.unit_price/100.0).to_s)    
   end
 
   xit "returns a invoice_item with a created_at" do


### PR DESCRIPTION
Report InvoiceItem price in dollars to be consistent with spec harness.
- Add serializer
- Adjust tests
