### PR TITLE
Create migration to change string fields to CIText

### DIFF
--- a/db/migrate/20160602053420_change_strings_to_ci_text.rb
+++ b/db/migrate/20160602053420_change_strings_to_ci_text.rb
@@ -1,0 +1,13 @@
+class ChangeStringsToCiText < ActiveRecord::Migration
+  def change
+    enable_extension 'citext'
+
+    change_column :customers, :first_name, :citext
+    change_column :customers, :last_name, :citext
+    change_column :invoices, :status, :citext
+    change_column :items, :name, :citext
+    change_column :items, :description, :citext
+    change_column :transactions, :result, :citext
+    change_column :merchants, :name, :citext
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,17 +11,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160601161606) do
+ActiveRecord::Schema.define(version: 20160602053420) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "citext"
 
   create_table "customers", force: :cascade do |t|
     t.string   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "first_name"
-    t.string   "last_name"
+    t.citext   "first_name"
+    t.citext   "last_name"
   end
 
   create_table "invoice_items", force: :cascade do |t|
@@ -41,15 +42,15 @@ ActiveRecord::Schema.define(version: 20160601161606) do
     t.integer  "merchant_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "status"
+    t.citext   "status"
   end
 
   add_index "invoices", ["customer_id"], name: "index_invoices_on_customer_id", using: :btree
   add_index "invoices", ["merchant_id"], name: "index_invoices_on_merchant_id", using: :btree
 
   create_table "items", force: :cascade do |t|
-    t.string   "name"
-    t.string   "description"
+    t.citext   "name"
+    t.citext   "description"
     t.integer  "unit_price"
     t.integer  "merchant_id"
     t.datetime "created_at"
@@ -59,7 +60,7 @@ ActiveRecord::Schema.define(version: 20160601161606) do
   add_index "items", ["merchant_id"], name: "index_items_on_merchant_id", using: :btree
 
   create_table "merchants", force: :cascade do |t|
-    t.string   "name"
+    t.citext   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -68,7 +69,7 @@ ActiveRecord::Schema.define(version: 20160601161606) do
     t.integer  "invoice_id"
     t.string   "credit_card_number"
     t.string   "credit_card_expiration_date"
-    t.string   "result"
+    t.citext   "result"
     t.datetime "created_at"
     t.datetime "updated_at"
   end


### PR DESCRIPTION
Use CIText over strings to allow for Case Insensitive searching.
